### PR TITLE
3.0.0-rc.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lottie-web-vue",
-  "version": "3.0.0",
+  "version": "3.0.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lottie-web-vue",
-      "version": "3.0.0",
+      "version": "3.0.0-rc.0",
       "license": "MIT",
       "dependencies": {
         "lottie-web": "^5.12.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-web-vue",
-  "version": "3.0.0",
+  "version": "3.0.0-rc.0",
   "description": "Airbnb Lottie-web component for Vue.js projects",
   "type": "module",
   "files": [


### PR DESCRIPTION
Version bump for the release-candidate rehearsal. Publishes to the `next` dist-tag when `v3.0.0-rc.0` is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)