### PR TITLE
Fix release workflow: remove registry-url that shadowed OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # NOTE: no registry-url here — it writes an .npmrc with an (empty)
+      # _authToken that shadows OIDC Trusted Publishing and breaks publish
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
-          registry-url: https://registry.npmjs.org
 
       # Trusted Publishing needs a recent npm on the runner
       - run: npm install -g npm@latest


### PR DESCRIPTION
The v3.0.0-rc.0 release run verified everything and signed provenance, but the registry PUT failed with E404: setup-node's `registry-url` writes an `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`, and with no token set npm authenticated with an empty token instead of the OIDC exchange. Removing `registry-url` lets npm's native Trusted Publishing handle auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)