### PR TITLE
3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.0.0 (unreleased)
+## 3.0.0 (2026-08-01)
 
 ### Breaking
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lottie-web-vue",
-  "version": "3.0.0-rc.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lottie-web-vue",
-      "version": "3.0.0-rc.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "lottie-web": "^5.12.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-web-vue",
-  "version": "3.0.0-rc.0",
+  "version": "3.0.0",
   "description": "Airbnb Lottie-web component for Vue.js projects",
   "type": "module",
   "files": [


### PR DESCRIPTION
Stable 3.0.0 release. The rc (3.0.0-rc.0) was verified on `@next`: live registry install, all consumer patterns, and a real-world 2022-era consumer project upgraded with zero source changes and rendered in a browser.

Tagging `v3.0.0` after merge publishes this as `latest` with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)