### PR TITLE
Release 3.0.1 (homepage → docs site)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.0.1 (2026-08-01)
+
+### Changed
+
+- Documentation website launched at
+  [garbit.github.io/lottie-web-vue](https://garbit.github.io/lottie-web-vue/)
+  with guides, full API reference, and live interactive demos. The
+  package `homepage` field now points there (this is what the npm
+  sidebar links to). No runtime changes.
+
 ## 3.0.0 (2026-08-01)
 
 ### Breaking

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lottie-web-vue",
-  "version": "3.0.0",
+  "version": "3.0.1-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lottie-web-vue",
-      "version": "3.0.0",
+      "version": "3.0.1-rc.0",
       "license": "MIT",
       "dependencies": {
         "lottie-web": "^5.12.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-web-vue",
-  "version": "3.0.0",
+  "version": "3.0.1-rc.0",
   "description": "Airbnb Lottie-web component for Vue.js projects",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary

Metadata-only release: the `homepage` field in `package.json` now points to the new documentation site (https://garbit.github.io/lottie-web-vue/), which is what the npm sidebar links to. The published 3.0.0 tarball still carries the old README link and registry metadata can't be edited in place, so this needs a version bump.

Starts at `3.0.1-rc.0` → publishes to the `next` dist-tag for a metadata check, then this branch gets a follow-up bump to stable `3.0.1`.

## Test plan

- [x] `npm run verify` locally (lint, typecheck, 28 unit tests, build, pack smoke test, 5 E2E)
- [ ] Tag `v3.0.1-rc.0` after merge → release workflow publishes to `next`
- [ ] `npm view lottie-web-vue@next homepage` shows the docs URL
- [ ] Promote to stable `3.0.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)