### PR TITLE
Release 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lottie-web-vue",
-  "version": "3.0.1-rc.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lottie-web-vue",
-      "version": "3.0.1-rc.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "lottie-web": "^5.12.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-web-vue",
-  "version": "3.0.1-rc.0",
+  "version": "3.0.1",
   "description": "Airbnb Lottie-web component for Vue.js projects",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary

Promotes `3.0.1-rc.0` to stable `3.0.1`. The rc published cleanly to the `next` dist-tag and `npm view lottie-web-vue@next homepage` confirms the metadata fix (`https://garbit.github.io/lottie-web-vue/`). CHANGELOG already carries the 3.0.1 entry from the rc PR (#35).

## Test plan

- [x] rc verified on `next` dist-tag
- [ ] CI green
- [ ] Tag `v3.0.1` after merge → release workflow publishes as `latest`
- [ ] npm sidebar Homepage shows the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)